### PR TITLE
Fixed Role Syncing for ROLE_NONE

### DIFF
--- a/lua/terrortown/entities/roles/wrath/shared.lua
+++ b/lua/terrortown/entities/roles/wrath/shared.lua
@@ -85,7 +85,14 @@ if SERVER then
 		-- hide the role from all players (including himself)
 		for wra in pairs(tbl) do
 			if wra:GetSubRole() == ROLE_WRATH and wra:GetNWBool("SpawnedAsWra", -1) == -1 then
-				tbl[wra] = {ROLE_INNOCENT, TEAM_INNOCENT}
+				-- show innocent for himself
+				if ply == wra then
+					tbl[wra] = {ROLE_INNOCENT, TEAM_INNOCENT}
+					
+				-- show none for everyone else
+				else
+					tbl[wra] = {ROLE_NONE, TEAM_NONE}
+				end
 			end
 		end
 	end)


### PR DESCRIPTION
Fixed Role Syncing for recent TTT2 update which adds ROLE_NONE and changes default role behavior.

Before, with the recent TTT2 update on GitHub (as of now not released on Workshop), if Wrath's role was hidden from himself, all players would see him as publicly innocent, this change fixes that.